### PR TITLE
create booking with Stripe and Stripe webhooks implemented

### DIFF
--- a/backend/db/migrations/20220715162810-create-booking.js
+++ b/backend/db/migrations/20220715162810-create-booking.js
@@ -43,6 +43,10 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DATE
       },
+      stripePaymentIntentId: {
+        allowNull: true,
+        type: Sequelize.STRING
+      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE

--- a/backend/db/models/booking.js
+++ b/backend/db/models/booking.js
@@ -7,7 +7,8 @@ module.exports = (sequelize, DataTypes) => {
     avePricePerDay: DataTypes.DECIMAL,
     numOfGuests: DataTypes.INTEGER,
     startDate: DataTypes.DATE,
-    endDate: DataTypes.DATE
+    endDate: DataTypes.DATE,
+    stripePaymentIntentId: DataTypes.STRING
   }, {});
   Booking.associate = function(models) {
     // associations can be defined here

--- a/backend/routes/api/bookings.js
+++ b/backend/routes/api/bookings.js
@@ -123,7 +123,7 @@ router.post("/create-payment-intent", async (req,res) => {
 // This is the Stripe CLI webhook secret for testing endpoint locally.
 let endpointSecret;
 
-endpointSecret = "whsec_1a43d283a95cca353365e5c538a5b0d750403558f2489e85441406391a3a0cf5";
+endpointSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
 router.post('/webhook', express.raw({type: 'application/json'}), async(request, response) => {
     const sig = request.headers['stripe-signature'];

--- a/backend/routes/api/bookings.js
+++ b/backend/routes/api/bookings.js
@@ -1,12 +1,12 @@
 const express = require('express');
 const asyncHandler = require('express-async-handler');
-
+require("dotenv").config()
 const { Booking, Listing, Image } = require('../../db/models');
 const { requireAuth } = require('../../utils/auth')
 
 const router = express.Router();
 
-
+const stripe = require("stripe")(process.env.STRIPE_PRIVATE_KEY)
 
 // get all user bookings
 router.get('/userBooking', requireAuth, asyncHandler(async (req, res) => {
@@ -60,9 +60,39 @@ router.delete('/:bookingId', requireAuth, asyncHandler(async (req, res) => {
     return res.json({ message: 'successfully deleted' })
 }));
 
+router.get("/stripeConfig", (req, res) => {
+    res.send({
+      publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
+    });
+  });
+
+router.post("/create-payment-intent", asyncHandler(async (req,res) => {
+    const {totalCost} = req.body;
+    try {
+        // use paymentIntenets.create() to allow more flexibility
+        const stripePayment = await stripe.paymentIntents.create({
+            currency: "usd",
+            amount: totalCost * 100, //calculated in cents
+            payment_method_types: ['card'],
+            automatic_payment_methods: { enabled: true },
+        });
+
+        return res.json({
+            stripePaymentId: stripePayment.id,
+            client_secret: paymentIntent.client_secret
+        });
+        } catch (error) {
+            return res.status(400).send({
+                error: {
+                  message: error.message,
+                },
+            });
+        };
+
+}));
 
 router.post('/create', requireAuth, asyncHandler(async (req, res) => {
-    const { totalCost, avePricePerDay, startDate, endDate, listingId, numOfGuests } = req.body;
+    const { totalCost, avePricePerDay, startDate, endDate, listingId, numOfGuests, stripePaymentIntentId } = req.body;
     
     const userId = req.user.id;
 
@@ -74,17 +104,27 @@ router.post('/create', requireAuth, asyncHandler(async (req, res) => {
         return res.json({ errors: ['No listing found.'] });
     }
 
-    const booking = await Booking.create({
-        userId,
-        listingId,
-        totalCost,
-        avePricePerDay,
-        numOfGuests,
-        startDate,
-        endDate     
-    });
+    try {
+        const booking = await Booking.create({
+            userId,
+            listingId,
+            totalCost,
+            avePricePerDay,
+            numOfGuests,
+            startDate,
+            endDate,
+            stripePaymentIntentId   
+        });
 
-    return res.json(booking);
+        return res.json({booking});
+
+    } catch (error) {
+        return res.status(400).send({
+            error: {
+                message: error.message,
+            },
+        });
+    };
 }));
 
 module.exports = router;

--- a/backend/routes/api/index.js
+++ b/backend/routes/api/index.js
@@ -69,6 +69,7 @@ router.use("/wishlists", wishListRouter);
 router.use("/bookings", bookingRouter);
 router.use("/distanceMatrix", distanceMatrix);
 
+
 router.get('/maps-key', (req, res) => {
   const apiKey = process.env.GOOGLE_MAPS_API_KEY;
   // console.log('THIS IS THE GOOGLE KEY', apiKey)


### PR DESCRIPTION
I implemented webhooks to listen for events on our Stripe account, so we can create a new booking by update our Bookings table if a Stripe checkout session is completed. To use webhooks locally, we will have to install Stripe cli.
To install Stripe cli, if you are on a mac, we can just install the cli using homebrew, in the terminal, enter:
brew install stripe/stripe-cli/stripe
and here is the [link to Stripe Cli installation](https://stripe.com/docs/stripe-cli).

Once Stripe cli is installed, we need to log in to stripe by enter the following into terminal:
stripe login

https://github.com/RawaMem/RealBnb/assets/67481206/ff7890b0-4e77-4d3a-b032-55c84dea7042


to start the webhooks event, we need to run the following in the terminal:
stripe listen --forward-to localhost:5000/bookings/webhook

Here is a video demo of create booking functionality:
